### PR TITLE
Improved bash script now works when script is symlinked

### DIFF
--- a/csv2db
+++ b/csv2db
@@ -20,10 +20,17 @@
 # limitations under the License.
 #
 
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
 # Check whether python 3 is available
 if command -v python3 &>/dev/null; then
-    CSV2DB_HOME_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-    ${CSV2DB_HOME_DIR}/src/python/csv2db.py "$@"
+    $DIR/src/python/csv2db.py "$@"
 else
     echo "Python 3 is not installed, please install Python 3 first."
     echo "For more information see https://www.python.org/downloads/"

--- a/src/python/csv2db.py
+++ b/src/python/csv2db.py
@@ -21,6 +21,7 @@
 #
 
 import argparse
+import getpass
 import sys
 
 import config as cfg
@@ -104,7 +105,8 @@ def run(cmd):
         f.verbose("Establishing database connection.")
         f.debug("Database details:")
         f.debug({"dbtype": args.dbtype, "user": args.user, "host": args.host, "port": args.port, "dbname": args.dbname})
-
+        if args.password is None:
+            args.password =  getpass.getpass()
         try:
             cfg.conn = f.get_db_connection(cfg.db_type, args.user, args.password, args.host, args.port, args.dbname)
         except Exception as err:
@@ -343,8 +345,8 @@ def parse_arguments(cmd):
                              help="The database type.")
     parser_load.add_argument("-u", "--user", required=True,
                              help="The database user to load data into.")
-    parser_load.add_argument("-p", "--password", required=True,
-                             help="The database schema password.")
+    parser_load.add_argument("-p", "--password", required=False,
+                             help="The database schema password. Will prompt if -p or --password is missing (more secure).")
     parser_load.add_argument("-m", "--host", default="localhost",
                              help="The host name on which the database is running on.")
     parser_load.add_argument("-n", "--port",


### PR DESCRIPTION
This change allows you to symlink to the bash script and exec from the symlink.  Credit for the soln goes [here](https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself)

The 2nd commit makes -p optional and prompts for the pw which is more secure.