### PR TITLE
Quote column names to avoid name colisions with reserved names or keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,13 +354,13 @@ SQL Server         | Does not care about the case sensitivity.
 # LICENSE
 
 	Copyright 2019 Gerald Venzl
-
+	
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
-
+	
 	    http://www.apache.org/licenses/LICENSE-2.0
-
+	
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,
 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Closing database connection.
 `csv2db` can generate the SQL statement for a staging table for your data using the `generate` command:
 
 ```sql
-$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv -o mysql
+$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv
 CREATE TABLE <TABLE NAME>
 (
   TRIPDURATION VARCHAR(1000),
@@ -219,7 +219,7 @@ CREATE TABLE <TABLE NAME>
 By default you will have to fill in the table name. You can also specify the table name via the `-t` option:
 
 ```sql
-$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv -t STAGING -o mysql
+$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv -t STAGING
 CREATE TABLE STAGING
 (
   TRIPDURATION VARCHAR(1000),
@@ -243,7 +243,7 @@ CREATE TABLE STAGING
 `csv2db` will use `VARCHAR(1000)` as default data type for all columns for the staging table. If you wish to use a different data type, you can specify it via the `-c` option:
 
 ```sql
-$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv -t STAGING -c CLOB -o mysql
+$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv -t STAGING -c CLOB
 CREATE TABLE STAGING
 (
   TRIPDURATION CLOB,

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ optional arguments:
 ```console
 $ ./csv2db generate -h
 usage: csv2db generate [-h] [-f FILE] [-v] [--debug] [-t TABLE]
+                       [-o {oracle,mysql,postgres,sqlserver,db2}]
                        [-c COLUMN_TYPE] [-s SEPARATOR] [-q QUOTE]
 
 optional arguments:
@@ -55,6 +56,8 @@ optional arguments:
   --debug               Debug output.
   -t TABLE, --table TABLE
                         The table name to use.
+  -o {oracle,mysql,postgres,sqlserver,db2}, --dbtype {oracle,mysql,postgres,sqlserver,db2}
+                        The database type.
   -c COLUMN_TYPE, --column-type COLUMN_TYPE
                         The column type to use for the table generation.
   -s SEPARATOR, --separator SEPARATOR
@@ -192,7 +195,7 @@ Closing database connection.
 `csv2db` can generate the SQL statement for a staging table for your data using the `generate` command:
 
 ```sql
-$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv
+$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv -o mysql
 CREATE TABLE <TABLE NAME>
 (
   TRIPDURATION VARCHAR(1000),
@@ -216,7 +219,7 @@ CREATE TABLE <TABLE NAME>
 By default you will have to fill in the table name. You can also specify the table name via the `-t` option:
 
 ```sql
-$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv -t STAGING
+$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv -t STAGING -o mysql
 CREATE TABLE STAGING
 (
   TRIPDURATION VARCHAR(1000),
@@ -240,7 +243,7 @@ CREATE TABLE STAGING
 `csv2db` will use `VARCHAR(1000)` as default data type for all columns for the staging table. If you wish to use a different data type, you can specify it via the `-c` option:
 
 ```sql
-$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv -t STAGING -c CLOB
+$ ./csv2db generate -f test/resources/201811-citibike-tripdata.csv -t STAGING -c CLOB -o mysql
 CREATE TABLE STAGING
 (
   TRIPDURATION CLOB,

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ optional arguments:
 $ ./csv2db generate -h
 usage: csv2db generate [-h] [-f FILE] [-v] [--debug] [-t TABLE]
                        [-o {oracle,mysql,postgres,sqlserver,db2}]
-                       [-c COLUMN_TYPE] [-s SEPARATOR] [-q QUOTE]
+                       [--quote-identifiers] [-c COLUMN_TYPE] [-s SEPARATOR]
+                       [-q QUOTE]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -58,6 +59,8 @@ optional arguments:
                         The table name to use.
   -o {oracle,mysql,postgres,sqlserver,db2}, --dbtype {oracle,mysql,postgres,sqlserver,db2}
                         The database type.
+  --quote-identifiers   SQL identifiers (table names and columns) are getting
+                        quoted.
   -c COLUMN_TYPE, --column-type COLUMN_TYPE
                         The column type to use for the table generation.
   -s SEPARATOR, --separator SEPARATOR
@@ -69,9 +72,10 @@ optional arguments:
 ```console
 $ ./csv2db load -h
 usage: csv2db load [-h] [-f FILE] [-v] [--debug] -t TABLE
-                   [-o {oracle,mysql,postgres,sqlserver,db2}] -u USER
-                   [-p PASSWORD] [-m HOST] [-n PORT] [-d DBNAME] [-b BATCH]
-                   [-s SEPARATOR] [-q QUOTE] [-a]
+                   [-o {oracle,mysql,postgres,sqlserver,db2}]
+                   [--quote-identifiers] -u USER [-p PASSWORD] [-m HOST]
+                   [-n PORT] [-d DBNAME] [-b BATCH] [-s SEPARATOR] [-q QUOTE]
+                   [-a]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -82,6 +86,8 @@ optional arguments:
                         The table name to use.
   -o {oracle,mysql,postgres,sqlserver,db2}, --dbtype {oracle,mysql,postgres,sqlserver,db2}
                         The database type.
+  --quote-identifiers   SQL identifiers (table names and columns) are getting
+                        quoted.
   -u USER, --user USER  The database user to load data into.
   -p PASSWORD, --password PASSWORD
                         The database schema password. csv2db will prompt for
@@ -120,7 +126,6 @@ $ ./csv2db load -f test/resources/201811-citibike-tripdata.csv.gz -t citibikes -
 
 Loading file test/resources/201811-citibike-tripdata.csv.gz
 File loaded.
-
 ```
 
 `csv2db` `--verbose` option will provide verbose output.
@@ -282,7 +287,7 @@ $ unzip csv2db.zip
 $ cd csv2db*
 $ ./csv2db
 ```
-    
+
 In order for `csv2db` to work you will have to install the appropriate database driver(s).
 The following drivers are being used, all available on [pypi.org](https://pypi.org/):
 
@@ -311,7 +316,7 @@ please see the documentation of the individual driver or refer to the
 # Miscellaneous
 
 ## Exit codes
-`csv2db` returns following exit codes:  
+`csv2db` returns following exit codes:
 
 Exit code          | Value | Meaning
 ------------------ | ----- | -------
@@ -322,21 +327,40 @@ DATABASE_ERROR     |     3 | A database error occurred.
 DATA_LOADING_ERROR |     4 | An error occurred during loading of data. `csv2db` will continue to process other files, if any.
 
 ## `$NO_COLOR` support
-`csv2db` is capable of color coded output and will do so by default (except on Windows).  
-<span style="color:yellow">Debug output is yellow.</span>  
-<span style="color:red">Error output is red.</span>  
+`csv2db` is capable of color coded output and will do so by default (except on Windows).
+<span style="color:yellow">Debug output is yellow.</span>
+<span style="color:red">Error output is red.</span>
 This can be deactivated by setting the `$NO_COLOR` environment variable. For more details on `$NO_COLOR` see https://no-color.org/
+
+## Quoting identifiers with `--quote-identifiers`
+
+Some words are reserved keywords in the database world.
+E.g., [`RANGE` in MySQL](https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-8-0-detailed-R), [`OPTION` in Oracle](https://doc.ispirer.com/sqlways/Output/SQLWays-1-134.html), [`AUDIT` in DB2](https://www.ibm.com/docs/en/db2-for-zos/11?topic=words-reserved).
+
+If your CSV contains a column named after a reserved keyword, you have to quote those identifiers to import the data by using the `--quote-identifiers` flag.
+
+One side effect of using quoted identifiers is:
+Some database systems treat the identifier as case-sensitive.
+See the table below for details.
+
+Database system    | Handling of case-sensitivity
+------------------ | ------------------------------
+DB2                | Without quotes, column names are uppercase by default. With quotes, names are used as provided.
+Oracle             | Without quotes, column names are uppercase by default. With quotes, names are used as provided.
+PostgreSQL         | Without quotes, column names are lowercase by default. With quotes, names are used as provided.
+MySQL              | Does not care about the case sensitivity.
+SQL Server         | Does not care about the case sensitivity.
 
 # LICENSE
 
 	Copyright 2019 Gerald Venzl
-	
+
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
-	
+
 	    http://www.apache.org/licenses/LICENSE-2.0
-	
+
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,
 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ please see the documentation of the individual driver or refer to the
 # Miscellaneous
 
 ## Exit codes
-`csv2db` returns following exit codes:
+`csv2db` returns following exit codes:  
 
 Exit code          | Value | Meaning
 ------------------ | ----- | -------
@@ -327,9 +327,9 @@ DATABASE_ERROR     |     3 | A database error occurred.
 DATA_LOADING_ERROR |     4 | An error occurred during loading of data. `csv2db` will continue to process other files, if any.
 
 ## `$NO_COLOR` support
-`csv2db` is capable of color coded output and will do so by default (except on Windows).
-<span style="color:yellow">Debug output is yellow.</span>
-<span style="color:red">Error output is red.</span>
+`csv2db` is capable of color coded output and will do so by default (except on Windows).  
+<span style="color:yellow">Debug output is yellow.</span>  
+<span style="color:red">Error output is red.</span>  
 This can be deactivated by setting the `$NO_COLOR` environment variable. For more details on `$NO_COLOR` see https://no-color.org/
 
 ## Quoting identifiers with `--quote-identifiers`

--- a/src/python/config.py
+++ b/src/python/config.py
@@ -34,3 +34,4 @@ db_type = None
 column_separator = ""
 quote_char = ""
 data_loading_error = False
+quote_identifiers = False

--- a/src/python/csv2db.py
+++ b/src/python/csv2db.py
@@ -177,7 +177,7 @@ def print_table_and_columns(col_list, column_data_type):
     print("(")
     cols = ""
     for col in col_list:
-        cols += "  " + col + " " + column_data_type + ",\n"
+        cols += "  `" + col + "` " + column_data_type + ",\n"
     cols = cols[:-2]
     print(cols)
     print(");")
@@ -220,6 +220,12 @@ def read_and_load_file(file):
     """
     reader = f.get_csv_reader(file)
     col_map = f.read_header(reader)
+
+    col_list = []
+    for col in col_map:
+        col_list.append("`" + col + "`")
+    col_map = col_list
+
     f.debug("Column map: {0}".format(col_map))
     for line in reader:
         load_data(col_map, line)

--- a/src/python/csv2db.py
+++ b/src/python/csv2db.py
@@ -53,6 +53,7 @@ def run(cmd):
 
     # Set table name
     cfg.table_name = args.table
+    # TODO Should we quote the table name in the debug output as well, once this is configured?
     f.debug("Table name: {0}".format(cfg.table_name))
 
     # Set column separator characters(s)

--- a/src/python/csv2db.py
+++ b/src/python/csv2db.py
@@ -178,7 +178,7 @@ def print_table_and_columns(col_list, column_data_type):
     print("(")
     cols = ""
     for col in col_list:
-        cols += " " + f.quote_field(cfg.db_type, col) + " " + column_data_type + ",\n"
+        cols += " " + f.quote(cfg.db_type, col) + " " + column_data_type + ",\n"
     cols = cols[:-2]
     print(cols)
     print(");")
@@ -224,7 +224,7 @@ def read_and_load_file(file):
 
     col_list = []
     for col in col_map:
-        col_list.append(f.quote_field(cfg.db_type, col))
+        col_list.append(f.quote(cfg.db_type, col))
     col_map = col_list
 
     f.debug("Column map: {0}".format(col_map))

--- a/src/python/csv2db.py
+++ b/src/python/csv2db.py
@@ -173,7 +173,7 @@ def print_table_and_columns(col_list, column_data_type):
         The data type to use for all columns
     """
     if cfg.table_name is not None:
-        print("CREATE TABLE {0}".format(cfg.table_name))
+        print("CREATE TABLE {0}".format(f.quote(cfg.db_type, cfg.table_name)))
     else:
         print("CREATE TABLE <TABLE NAME>")
     print("(")
@@ -223,6 +223,7 @@ def read_and_load_file(file):
     reader = f.get_csv_reader(file)
     col_map = f.read_header(reader)
 
+    # Quoting field names
     col_list = []
     for col in col_map:
         col_list.append(f.quote(cfg.db_type, col))
@@ -304,8 +305,9 @@ def generate_statement(col_map):
         values = ("?," * len(col_map))[:-1]
     else:
         values = ("%s, " * len(col_map))[:-2]
+
     return "INSERT{0} INTO {1} ({2}) VALUES ({3})".format(append_hint,
-                                                          cfg.table_name,
+                                                          f.quote(cfg.db_type, cfg.table_name),
                                                           ", ".join(col_map),
                                                           values)
 

--- a/src/python/csv2db.py
+++ b/src/python/csv2db.py
@@ -72,6 +72,10 @@ def run(cmd):
         return f.ExitCodes.SUCCESS.value
     f.debug(file_names)
 
+    # Set DB type
+    f.debug("DB type: {0}".format(args.dbtype))
+    cfg.db_type = args.dbtype
+
     # Generate CREATE TABLE SQL
     if args.command.startswith("gen"):
         f.verbose("Generating CREATE TABLE statement.")
@@ -86,9 +90,6 @@ def run(cmd):
 
     # Load data
     else:
-        # Set DB type
-        f.debug("DB type: {0}".format(args.dbtype))
-        cfg.db_type = args.dbtype
         cfg.direct_path = args.directpath
         # Set DB default port, if needed
         if args.port is None:
@@ -177,7 +178,7 @@ def print_table_and_columns(col_list, column_data_type):
     print("(")
     cols = ""
     for col in col_list:
-        cols += "  `" + col + "` " + column_data_type + ",\n"
+        cols += " " + f.quote_field(cfg.db_type, col) + " " + column_data_type + ",\n"
     cols = cols[:-2]
     print(cols)
     print(");")
@@ -223,7 +224,7 @@ def read_and_load_file(file):
 
     col_list = []
     for col in col_map:
-        col_list.append("`" + col + "`")
+        col_list.append(f.quote_field(cfg.db_type, col))
     col_map = col_list
 
     f.debug("Column map: {0}".format(col_map))
@@ -342,6 +343,8 @@ def parse_arguments(cmd):
                                  help="Debug output.")
     parser_generate.add_argument("-t", "--table",
                                  help="The table name to use.")
+    parser_generate.add_argument("-o", "--dbtype", default="oracle", choices=[e.value for e in f.DBType],
+                                 help="The database type.")
     parser_generate.add_argument("-c", "--column-type", default="VARCHAR(1000)",
                                  help="The column type to use for the table generation.")
     parser_generate.add_argument("-s", "--separator", default=",",

--- a/src/python/functions.py
+++ b/src/python/functions.py
@@ -329,7 +329,7 @@ def executemany(cur, stmt):
             p.execute_batch(cur, stmt, cfg.input_data)
 
 
-def quote_field(db_type: str, value: str) -> str:
+def quote(db_type: str, value: str) -> str:
     """
     Quotes the {value} with the correct character
     depending on the database type.

--- a/src/python/functions.py
+++ b/src/python/functions.py
@@ -327,3 +327,27 @@ def executemany(cur, stmt):
         else:
             import psycopg2.extras as p
             p.execute_batch(cur, stmt, cfg.input_data)
+
+
+def quote_field(db_type: str, value: str) -> str:
+    """
+    Quotes the {value} with the correct character
+    depending on the database type.
+
+    Mainly to avoid name collisions of columns with
+    reserved keywords.
+
+    :param db_type: Database type. See DBType class for possible values.
+    :param value: Value to quote
+    :return: Quoted value. If no database type matches, value is returned like passed
+    """
+    if db_type in [DBType.ORACLE.value, DBType.POSTGRES.value, DBType.DB2.value]:
+        return f"\"{value}\""
+
+    if db_type == DBType.MYSQL.value:
+        return f"`{value}`"
+
+    if db_type == DBType.SQLSERVER.value:
+        return f"[{value}]"
+
+    return value

--- a/src/python/functions.py
+++ b/src/python/functions.py
@@ -347,6 +347,16 @@ def quote_field(db_type: str, value: str) -> str:
     if db_type == DBType.MYSQL.value:
         return f"`{value}`"
 
+    # TODO Figure out what is the right way to quote SQL-Server words
+    # Context:
+    #   SQL-Server / MSSQL supports quoting via [] and ", depending on a config setting.
+    #   [] is considered legacy, " is the new default.
+    #   However, old instances can still have the old setting enabled.
+    #   Multiple options:
+    #       1. Use only the new one and say "no legacy supported"
+    #       2. Find a way to query the setting from the SQL-Server and decide then
+    #
+    #   See https://github.com/csv2db/csv2db/pull/51 for full context
     if db_type == DBType.SQLSERVER.value:
         return f"[{value}]"
 


### PR DESCRIPTION
**What type of PR is this?**

bug

**What this PR does / why we need it**:

Imagine we have this CSV file (called `nutrient.csv`, from the https://fdc.nal.usda.gov/download-datasets.html // Supporting data for Downloads - April 2021 (CSV – 1.0M):

```
id,name,unit_name,nutrient_nbr,rank
1001,Solids,G,201,200
1002,Nitrogen,G,202,500
1003,Protein,G,203,600
1004,Total lipid (fat),G,204,800
1005,"Carbohydrate, by difference",G,205,1110
```

The command `./csv2db generate --file nutrient.csv --table nutrient --verbose` generates:

```
Finding file(s).
Found 1 file(s).
Generating CREATE TABLE statement.
CREATE TABLE nutrient
(
  ID VARCHAR(1000),
  NAME VARCHAR(1000),
  UNIT_NAME VARCHAR(1000),
  NUTRIENT_NBR VARCHAR(1000),
  RANK VARCHAR(1000)
);
```

Executing this query against a MySQL Community Server - GPL 8.0.21. will result in

```
[ERROR in query 2] You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'RANK VARCHAR(1000)
)' at line 7
```

The reason: `RANK` is not quoted and [a reserved keyword since MySQL 8.0.2](https://dev.mysql.com/doc/refman/8.0/en/keywords.html).

A similar error will happen for the insert statements.

Solution: Quoting column names.

This PR quotes the column names in the CREATE and INSERT statements.

**Special notes for your reviewer**:

This was tested against MySQL Community Server - GPL 8.0.21.
Other database types were not tested.