### PR TITLE
Introduce new flag `-keep-column-names` to not uppercase column names

### DIFF
--- a/src/python/config.py
+++ b/src/python/config.py
@@ -34,3 +34,4 @@ db_type = None
 column_separator = ""
 quote_char = ""
 data_loading_error = False
+keep_column_names = False

--- a/src/python/functions.py
+++ b/src/python/functions.py
@@ -31,6 +31,8 @@ import sys
 import traceback
 from enum import Enum
 import csv
+from typing import List
+
 
 import config as cfg
 
@@ -100,8 +102,25 @@ def read_header(reader):
         A list with all the column names.
     """
     header = []
-    header.extend(col.replace(' ', '_',).upper() for col in next(reader))
+    header.extend(col.replace(' ', '_',) for col in next(reader))
     return header
+
+
+def uppercase_list(items: List[str]) -> List[str]:
+    """Makes all elements in list `items` uppercase.
+
+    Parameters
+    ----------
+    items : List[str]
+        Items to process
+
+    Returns
+    -------
+    List[str]
+        A list with all the items in uppercase.
+    """
+    uppercase_items = [item.upper() for item in items]
+    return uppercase_items
 
 
 def find_all_files(pattern):


### PR DESCRIPTION
**What this Pull Request does / why we need it**:

Right now, all columns names of a schema get uppercased automatically.
For my use case, I want to keep the names as provided.
In MySQL, this is not an issue.

Imagine you have this CSV file:

```csv
foo,bar,baz
1,3,hey
2,6,ho
3,9,lets
4,12,go
```

Running 

```sh
./csv2db generate --file test.csv --table tblname --keep-column-names
```

will  lead to

```sql
CREATE TABLE tblname
(
  foo VARCHAR(1000),
  bar VARCHAR(1000),
  baz VARCHAR(1000)
);
```

while the old behavior is still the default. Running 

```sh
./csv2db generate --file test.csv --table tblname
```

will lead to

```sql
CREATE TABLE tblname
(
  FOO VARCHAR(1000),
  BAR VARCHAR(1000),
  BAZ VARCHAR(1000)
);
```

**Special notes for the reviewer**:

The current, default, behaviour is not changed.